### PR TITLE
Mouse picking

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -8,6 +8,11 @@ float radius = 3.0f;
 
 glm::vec3 cameraDirection; 
 
+void Camera::SetP(glm::mat4 matrix) {
+    p = matrix;
+    inverseP = glm::inverse(matrix);
+}
+
 Camera::Camera() {
     // placeholder
     // v = glm::lookAt(glm::vec3(0.0f, 1.5f, -1.5f), glm::vec3(0.0f, 1.0f, 0.0f), glm::vec3(0.0f, 1.0f, 0.0f));
@@ -55,7 +60,24 @@ glm::vec3 Camera::GetRight() const {
     return glm::normalize(glm::cross(UP, cameraDirection));
 }
 
-
 glm::mat4 Camera::GetOrtho() const {
     return glm::ortho(0.0f, screenSize.x, 0.0f, screenSize.y);
+}
+
+Ray Camera::ViewportToRay(float x, float y) const {
+    // viewport -> nds -> clip space
+    // ignore perspective division -- ray has no depth
+    glm::vec4 clip = glm::vec4(
+        (2.f * x) / screenSize.x - 1.f,
+        1.f - (2.f * y) / screenSize.y,
+        -1.f,
+        1.f
+    );
+
+    glm::vec4 eye = inverseP * clip;
+    
+    return Ray(
+        GetPosition(),
+        glm::normalize(glm::inverse(GetV()) * glm::vec4(eye.x, eye.y, -1.f, 0.f))
+    );
 }

--- a/src/camera.h
+++ b/src/camera.h
@@ -2,15 +2,18 @@
 
 #include <glm/matrix.hpp>
 #include "transform.h"
+#include "utility.h"
 
 
 class Camera : public Transformable
 {
-private:
+protected:
     constexpr static glm::vec4 FORWARD = glm::vec4(0.0f, 0.0f, -1.0f, 0.0f);
     constexpr static glm::vec3 UP = glm::vec3(0.0f, 1.0f, 0.0f);
-    glm::mat4 p;
+    glm::mat4 p, inverseP;
     glm::vec2 screenSize;
+
+    void SetP(glm::mat4 matrix);
 public:
     Camera();
 
@@ -37,6 +40,8 @@ public:
     void SetScreenSize(float width, float height);
     glm::vec2 GetScreenSize() const;
     glm::mat4 GetOrtho() const;
+
+    Ray ViewportToRay(float x, float y) const;
 
 };
 

--- a/src/gamegrid.cpp
+++ b/src/gamegrid.cpp
@@ -286,7 +286,7 @@ GameGrid::GameGridMesh GameGrid::generateBaseMesh(GameGrid::MeshVersion version)
 Plane GameGrid::GetMousePickPlane() const {
     return Plane(
         gridToModelPosition({0, 0}),
-        glm::normalize(depthVector)
+        glm::normalize(-depthVector)
     );
 }
 

--- a/src/gamegrid.cpp
+++ b/src/gamegrid.cpp
@@ -3,6 +3,7 @@
 #include "utility.h"
 #include "grid.h"
 #include "BaseMesh.h"
+#include "gridobject.h"
 
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
@@ -10,7 +11,7 @@
 
 #include <vector>
 
-GameGrid::GameGridPosition GameGrid::gridToModelPosition(Grid::GridPosition p) {
+GameGrid::GameGridPosition GameGrid::gridToModelPosition(Grid::GridPosition p) const {
     if (!logicalGrid.isInsideGrid(p)) {
         return {-1, -1, -1};
     }
@@ -18,7 +19,7 @@ GameGrid::GameGridPosition GameGrid::gridToModelPosition(Grid::GridPosition p) {
     return { p.row + halfRowScale, cellElevation(p), p.col + halfColScale };
 }
 
-inline float GameGrid::cellElevation(Grid::GridPosition p) {
+inline float GameGrid::cellElevation(Grid::GridPosition p) const {
     if (logicalGrid.isInsideGrid(p))
         return logicalGrid.isLand(p) ? elevationStep : 0;
     return elevationStep;
@@ -280,4 +281,15 @@ GameGrid::GameGridMesh GameGrid::generateBaseMesh(GameGrid::MeshVersion version)
     }
     
     return mesh;
+}
+
+Plane GameGrid::GetMousePickPlane() const {
+    return Plane(
+        gridToModelPosition({0, 0}),
+        glm::normalize(depthVector)
+    );
+}
+
+Grid& GameGrid::GetLogical() {
+    return logicalGrid;
 }

--- a/src/gamegrid.h
+++ b/src/gamegrid.h
@@ -2,6 +2,7 @@
 
 #include "grid.h"
 #include "BaseMesh.h"
+#include "utility.h"
 
 #include <vector>
 #include <glm/glm.hpp>
@@ -64,8 +65,8 @@ private:
 
     const GameGridPosition depthVector = { 0.f, -elevationStep, 0.f};
     
-    GameGridPosition gridToModelPosition(Grid::GridPosition p);
-    inline float cellElevation(Grid::GridPosition p);
+    GameGridPosition gridToModelPosition(Grid::GridPosition p) const;
+    inline float cellElevation(Grid::GridPosition p) const;
     float cornerElevation(Grid::GridPosition a, Grid::GridPosition b, Grid::GridPosition c);
 
     void appendTriangle(std::vector<glm::vec4>& vertexArray, GameGridPosition a, GameGridPosition b, GameGridPosition c);
@@ -94,4 +95,7 @@ public:
     };
     GameGridMesh generateBaseMesh(MeshVersion version);
     GameGrid(const std::vector<std::string>& map) : logicalGrid(map) {}
+
+    Plane GetMousePickPlane() const;
+    Grid& GetLogical();
 };

--- a/src/gridobject.cpp
+++ b/src/gridobject.cpp
@@ -46,3 +46,7 @@ void GridObject::Draw(const Camera& camera) const {
 }
 
 void GridObject::Update(double deltaTime){}
+
+Grid& GridObject::GetLogical() {
+	return m_grid;
+}

--- a/src/gridobject.cpp
+++ b/src/gridobject.cpp
@@ -50,3 +50,7 @@ void GridObject::Update(double deltaTime){}
 Grid& GridObject::GetLogical() {
 	return m_grid;
 }
+
+Plane GridObject::GetMousePickPlane() const {
+	return m_plane.ToWorldSpace(GetTransformMatrix());
+}

--- a/src/gridobject.h
+++ b/src/gridobject.h
@@ -7,10 +7,17 @@
 
 class GridObject : public GameObject {
 private:
+    Grid m_grid;
     GameGrid::GameGridMesh m_mesh;
     Plane m_plane;
 public:
-    GridObject(const GameGrid::GameGridMesh &mesh, Plane pickPlane) : m_mesh(mesh), m_plane(pickPlane) {}
+    GridObject(
+        const GameGrid::GameGridMesh &mesh,
+        const Plane& pickPlane,
+        const Grid& logicalGrid
+    ) : m_mesh(mesh), m_plane(pickPlane), m_grid(logicalGrid) {}
+    
     void Draw(const Camera& camera) const override;
     void Update(double deltaTime) override;
+    Grid& GetLogical();
 };

--- a/src/gridobject.h
+++ b/src/gridobject.h
@@ -3,11 +3,14 @@
 #include "gameobject.h"
 #include "gamegrid.h"
 #include "camera.h"
+#include "utility.h"
 
 class GridObject : public GameObject {
-public:
+private:
     GameGrid::GameGridMesh m_mesh;
-    GridObject(const GameGrid::GameGridMesh &mesh) : m_mesh(mesh) {}
+    Plane m_plane;
+public:
+    GridObject(const GameGrid::GameGridMesh &mesh, Plane pickPlane) : m_mesh(mesh), m_plane(pickPlane) {}
     void Draw(const Camera& camera) const override;
     void Update(double deltaTime) override;
 };

--- a/src/gridobject.h
+++ b/src/gridobject.h
@@ -16,8 +16,9 @@ public:
         const Plane& pickPlane,
         const Grid& logicalGrid
     ) : m_mesh(mesh), m_plane(pickPlane), m_grid(logicalGrid) {}
-    
+
     void Draw(const Camera& camera) const override;
     void Update(double deltaTime) override;
     Grid& GetLogical();
+    Plane GetMousePickPlane() const;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,6 @@ void key_callback(GLFWwindow* window, int key, int scancode, int action, int mod
 	scene->OnKey(window, key, scancode, action, mod);
 }
 
-
 void mouse_callback(GLFWwindow* window, double xpos, double ypos) {
 	scene->OnMouse(window, xpos, ypos);
 }
@@ -92,7 +91,6 @@ int main(void)
 	glfwSetCursorPosCallback(window, mouse_callback);
 	glfwSetMouseButtonCallback(window, mouse_button_callback);
 	glfwSetScrollCallback(window, scroll_callback);
-	glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);  
 
 	glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
 

--- a/src/rtscamera.cpp
+++ b/src/rtscamera.cpp
@@ -16,7 +16,7 @@ RTSCamera::RTSCamera(glm::vec3 startPosition){
     cameraRight = glm::normalize(glm::cross(up, cameraDirection));
     cameraUp = glm::cross(cameraDirection, cameraRight);
 
-    P = glm::perspective(glm::radians(50.0f), 1.0f, 0.01f, 100.0f);
+    SetP(glm::perspective(glm::radians(50.0f), 1.0f, 0.01f, 100.0f));
 
     view = glm::lookAt(
         startPosition, 
@@ -47,6 +47,9 @@ void RTSCamera::MoveCamera(
     
         cameraPos += deltaTime * frontSpeedMove * cameraFront;
         cameraPos += deltaTime * rightSpeedMove * glm::normalize(glm::cross(cameraFront, cameraUp));
+
+        // HACK: To make this 'workarodund' work with systems reliant on Transform
+        SetPosition(cameraPos);
         
             //Mouse camera rotation
             glm::vec3 direction;
@@ -57,10 +60,6 @@ void RTSCamera::MoveCamera(
         
         view = glm::lookAt(cameraPos, cameraPos + cameraFront, cameraUp);
     }
-}
-
-glm::mat4 RTSCamera::GetP() const{
-    return P;
 }
 
 glm::mat4 RTSCamera::GetV() const{
@@ -76,10 +75,12 @@ void RTSCamera::SetCameraHeightCap(bool toggle, float cap){
     if(toggle){
         useHeightCap = !useHeightCap;
         cameraPos.y = heightCap;
+        
+        // HACK: To make this 'workarodund' work with systems reliant on Transform
+        SetPosition(cameraPos);
     }
 }
 
 void RTSCamera::ZoomCamera(float fov){
-    std::cerr<<"Zoom: "<<fov<<std::endl;
-    P = glm::perspective(glm::radians(fov), 1.0f, 0.01f, 100.0f);
+    SetP(glm::perspective(glm::radians(fov), 1.0f, 0.01f, 100.0f));
 }

--- a/src/rtscamera.h
+++ b/src/rtscamera.h
@@ -19,7 +19,6 @@ class RTSCamera : public Camera
         float radius = 5.0f;
         float camX = 0.0f, camZ = 0.0f;
         double time = 0.0f;
-        glm::mat4 P;
 
         glm::vec3 cameraFront = glm::vec3(0.0f, 0.0f, -1.0f);
 
@@ -47,5 +46,4 @@ class RTSCamera : public Camera
         
 
         glm::mat4 GetV() const override;
-        glm::mat4 GetP() const override;
 };

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -31,7 +31,7 @@ void Scene::OnScroll(GLFWwindow* window, double xoffset, double yoffset) {
     // ???
 }
 
-void Scene::Instantiate(std::unique_ptr<GameObject> object) {
+void Scene::Instantiate(std::shared_ptr<GameObject> object) {
     objects.push_back(std::move(object));
 }
 
@@ -45,7 +45,7 @@ void Scene::UpdateDrawOrder() {
     std::sort(
         objects.begin(),
         objects.end(),
-        [camera](const std::unique_ptr<GameObject>& a, const std::unique_ptr<GameObject>& b) -> bool {
+        [camera](const std::shared_ptr<GameObject>& a, const std::shared_ptr<GameObject>& b) -> bool {
             return a->GetOrder(camera) > b->GetOrder(camera);
         }
     );

--- a/src/scene.h
+++ b/src/scene.h
@@ -9,7 +9,7 @@
 class Scene
 {
   protected:
-      std::vector<std::unique_ptr<GameObject>> objects;
+      std::vector<std::shared_ptr<GameObject>> objects;
       RTSCamera activeCamera;
   public:
     Scene() = default;
@@ -24,7 +24,7 @@ class Scene
     virtual void OnMouse(GLFWwindow* window, double xpos, double ypos);
     virtual void OnMouseButton(GLFWwindow* window, int button, int action, int mods);
     virtual void OnScroll(GLFWwindow* window, double xoffset, double yoffset);
-    void Instantiate(std::unique_ptr<GameObject> object);
+    void Instantiate(std::shared_ptr<GameObject> object);
     void SetScreenSize(float width, float height);
     void UpdateDrawOrder();
 };

--- a/src/sillyscene.cpp
+++ b/src/sillyscene.cpp
@@ -165,6 +165,23 @@ void SillyScene::OnMouseButton(GLFWwindow* window, int button, int action, int m
 		}
 
 		// do mouse pick
+		Ray ray = activeCamera.ViewportToRay(lastX, lastY);
+		glm::vec3 hit;
+		if (ray.Intersect(gridObj->GetMousePickPlane(), hit))
+		{
+			std::cerr << "Hit: X: " << hit.x << " Y: " << hit.y << " Z: " << hit.z << std::endl;
+			
+			// gridObj->GetLogical()
+			// world to grid position
+			// Check money/whatever
+			// Place tower
+		}
+		else
+		{
+			std::cerr << "No hit!\n";
+		}
+		
+
 	}
 	else if (button == GLFW_MOUSE_BUTTON_RIGHT && action == GLFW_PRESS)
 	{

--- a/src/sillyscene.cpp
+++ b/src/sillyscene.cpp
@@ -7,7 +7,7 @@
 #include "text.h"
 #include "skybox.h"
 
-#define PI 2.141592f // close enough
+#define PI 3.141592f // close enough
 
 #define cameraMoveSpeed 2.5f
 #define mouseSensitivity 0.25f
@@ -44,8 +44,14 @@ SillyScene::SillyScene() {
 	// GameGrid grid({{{"xxx", "xSx", "x.x", "xEx", "xxx"}}});
 	GameGrid::GameGridMesh mesh = grid.generateBaseMesh(GameGrid::MESH_V_SECOND);
 	std::cerr << "n of mesh vertices: " << mesh.vertices.size() << std::endl;
-	auto objGrid = std::make_shared<GridObject>(mesh, Plane({0.f, 0.f, 0.f}, {0.f, 1.f, 0.f}));
-	Instantiate(std::move(objGrid));
+
+	gridObj = std::make_shared<GridObject>(
+		mesh,
+		grid.GetMousePickPlane(),
+		grid.GetLogical()
+	);
+
+	Instantiate(gridObj);
 
 	Instantiate(std::move(std::make_shared<Skybox>()));
 

--- a/src/sillyscene.cpp
+++ b/src/sillyscene.cpp
@@ -20,11 +20,11 @@ SillyScene::SillyScene() {
   activeCamera = RTSCamera(startCameraPosition);
   activeCamera.SetCameraHeightCap(true, cameraHeightCap);
 
-	auto objAssimp = std::make_unique<AssimpObject>();
+	auto objAssimp = std::make_shared<AssimpObject>();
 	Instantiate(std::move(objAssimp));
 
 	// remove if annoying
-	auto txt = std::make_unique<Text>("Graphics programming\nis my passion");
+	auto txt = std::make_shared<Text>("Graphics programming\nis my passion");
 	txt->SetOrigin(glm::vec2(0.02f, 0.5f));
 	txt->SetColor(glm::vec4(1.0f, 0.2f, 0.3f, 0.7f));
 	txt->SetScale(0.8f);
@@ -44,10 +44,10 @@ SillyScene::SillyScene() {
 	// GameGrid grid({{{"xxx", "xSx", "x.x", "xEx", "xxx"}}});
 	GameGrid::GameGridMesh mesh = grid.generateBaseMesh(GameGrid::MESH_V_SECOND);
 	std::cerr << "n of mesh vertices: " << mesh.vertices.size() << std::endl;
-	auto objGrid = std::make_unique<GridObject>(mesh);
+	auto objGrid = std::make_shared<GridObject>(mesh);
 	Instantiate(std::move(objGrid));
 
-	Instantiate(std::move(std::make_unique<Skybox>()));
+	Instantiate(std::move(std::make_shared<Skybox>()));
 
 	// HACK: We can get away with only doing this at scene init, SO LONG AS:
 	//     1) No transparent objects exist in the scene besides Text objects

--- a/src/sillyscene.h
+++ b/src/sillyscene.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <iostream>
 #include "scene.h"
+#include "gridobject.h"
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -13,7 +14,7 @@ private:
     float fov = 50.0f;
     bool firstMouse = true, focus = true, freeFlight = false, doCameraRotation = false;
     void updateCursorState(GLFWwindow* window);
-    std::shared_ptr<GameObject> gridObj;
+    std::shared_ptr<GridObject> gridObj;
 public:
     SillyScene();
     SillyScene(const SillyScene&) = delete;

--- a/src/sillyscene.h
+++ b/src/sillyscene.h
@@ -11,7 +11,8 @@ private:
     float yaw = -90, pitch = -45, speed_fwd = 0, speed_right = 0;
     float lastX = 0, lastY = 0;
     float fov = 50.0f;
-    bool firstMouse = true, focus = true, freeFlight = false;
+    bool firstMouse = true, focus = true, freeFlight = false, doCameraRotation = false;
+    void updateCursorState(GLFWwindow* window);
 public:
     SillyScene();
     SillyScene(const SillyScene&) = delete;

--- a/src/sillyscene.h
+++ b/src/sillyscene.h
@@ -13,6 +13,7 @@ private:
     float fov = 50.0f;
     bool firstMouse = true, focus = true, freeFlight = false, doCameraRotation = false;
     void updateCursorState(GLFWwindow* window);
+    std::shared_ptr<GameObject> gridObj;
 public:
     SillyScene();
     SillyScene(const SillyScene&) = delete;

--- a/src/utility.h
+++ b/src/utility.h
@@ -2,6 +2,7 @@
 #define UTILITY_H_
 
 #include <glm/glm.hpp>
+#include <glm/gtx/intersect.hpp>
 
 #include <vector>
 
@@ -11,6 +12,44 @@ struct Plane
     glm::vec3 normal;
 
     Plane(glm::vec3 point, glm::vec3 normal) : point(point), normal(normal) {}
+
+    Plane ToWorldSpace(glm::mat4 model) const {
+        return Plane(
+            model * glm::vec4(point, 1.f),
+            model * glm::vec4(normal, 0.f)
+        );
+    }
+};
+
+struct Ray
+{
+    glm::vec3 origin;
+    glm::vec3 direction;
+
+    Ray(glm::vec3 origin, glm::vec3 direction) : origin(origin), direction(direction) {}
+
+    Ray ToWorldSpace(glm::mat4 model) const {
+        return Ray(
+            model * glm::vec4(origin, 1.f),
+            model * glm::vec4(direction, 0.f)
+        );
+    }
+
+    bool Intersect(Plane plane, glm::vec3& hit) const {
+        float t;
+
+        bool didHit = glm::intersectRayPlane(
+            origin,
+            direction,
+            plane.point,
+            plane.normal,
+            t
+        );
+
+        hit = origin + t * direction;
+
+        return didHit;
+    }
 };
 
 // Initialize empty matrix made of std::vector 

--- a/src/utility.h
+++ b/src/utility.h
@@ -5,6 +5,14 @@
 
 #include <vector>
 
+struct Plane
+{
+    glm::vec3 point;
+    glm::vec3 normal;
+
+    Plane(glm::vec3 point, glm::vec3 normal) : point(point), normal(normal) {}
+};
+
 // Initialize empty matrix made of std::vector 
 // Example usage: (initialize 5x4 matrix of one's)
 // 1. std::vector<std::vector<int>> matrix; 


### PR DESCRIPTION
Changed camera control: hold RMB to rotate.
Added raycasting from camera position to (infinite) plane, aligned grass-level with grid.
Notably, changed unique to shared ptr in scene object containers.