### PR TITLE
Add scene transition mechanism

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,6 +105,18 @@ int main(void)
 		glfwSetTime(0);
 
 		scene->Update(dt);
+
+		if (scene->IsTransitionInitiated())
+		{
+			auto progenitor = std::move(scene);
+
+			scene = progenitor->GetTransitionTarget();
+
+			int width, height;
+			glfwGetWindowSize(window, &width, &height);
+			scene->SetScreenSize(width, height);
+		}	
+
         scene->Draw();
 
         glfwSwapBuffers(window);

--- a/src/mobobject.h
+++ b/src/mobobject.h
@@ -50,8 +50,8 @@ public:
         return reachedPathExit(currentPos);
     }
 
-    inline bool activate() { active  = true; }
-    inline bool deactivate() { active = false; } 
+    inline void activate() { active  = true; }
+    inline void deactivate() { active = false; } 
     
     inline PathIndex translateToPathIndex(SegmentIndex idx) const { return idx * 2 + 1; }
     inline SegmentIndex translateToSegmentIndex(PathIndex idx) const { return (idx - 1) / 2; }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -4,6 +4,10 @@
 #include <algorithm>
 
 
+void Scene::SceneTransition() {
+    transitionFlag = true;
+}
+
 void Scene::Update(double dt) {
     for (auto& object : objects)
         object->Update(dt);

--- a/src/scene.h
+++ b/src/scene.h
@@ -8,16 +8,22 @@
 
 class Scene
 {
-  protected:
-      std::vector<std::shared_ptr<GameObject>> objects;
-      RTSCamera activeCamera;
-  public:
+protected:
+    std::vector<std::shared_ptr<GameObject>> objects;
+    RTSCamera activeCamera;
+    bool transitionFlag = false;
+    virtual void SceneTransition();
+public:
     Scene() = default;
     Scene(const Scene&) = delete;
     Scene& operator=(const Scene&) = delete;
     Scene(Scene&&) = default;
     Scene& operator=(Scene&&) = default;
     ~Scene() = default;
+
+    inline bool IsTransitionInitiated() const { return transitionFlag; };
+    virtual std::unique_ptr<Scene> GetTransitionTarget() const = 0;
+
     virtual void Update(double dt);
     virtual void Draw() const;
     virtual void OnKey(GLFWwindow* window, int key, int scancode, int action, int mod);

--- a/src/sillyscene.cpp
+++ b/src/sillyscene.cpp
@@ -16,12 +16,20 @@
 #define pitchLowerBound -70.0f
 #define pitchUpperBound -30.0f
 
+// Add arguments if necessary
+void SillyScene::SceneTransition() {
+	// Save any parameters of the target scene here
+
+	// ALWAYS call super at the end
+	Scene::SceneTransition();
+}
+
 SillyScene::SillyScene() {
   activeCamera = RTSCamera(startCameraPosition);
   activeCamera.SetCameraHeightCap(true, cameraHeightCap);
 
-	auto objAssimp = std::make_shared<AssimpObject>();
-	Instantiate(std::move(objAssimp));
+	// auto objAssimp = std::make_shared<AssimpObject>();
+	// Instantiate(std::move(objAssimp));
 
 
 	// remove if annoying
@@ -66,12 +74,20 @@ SillyScene::SillyScene() {
 }
 
 
+std::unique_ptr<Scene> SillyScene::GetTransitionTarget() const {
+	// If necessary, use different Scene subtype
+	auto scn = std::make_unique<SillyScene>();
+	
+	// Apply saved parameters
+
+	return scn;
+}
+
 void SillyScene::Update(double dt) {
 	//roll inactive for now
 	activeCamera.MoveCamera(speed_fwd, speed_right, pitch, yaw, 0, (float)dt);
 
-	for (auto &object : objects)
-		object->Update(dt);
+	Scene::Update(dt);
 }
 
 void SillyScene::OnKey(GLFWwindow* window, int key, int scancode, int action, int mod) {
@@ -113,6 +129,9 @@ void SillyScene::OnKey(GLFWwindow* window, int key, int scancode, int action, in
 			}
 		}
 		
+		if (key == GLFW_KEY_X) {
+			SceneTransition();
+		}
 	}
 	if (action == GLFW_RELEASE) {
 		if (key == GLFW_KEY_LEFT || key == GLFW_KEY_RIGHT) {

--- a/src/sillyscene.h
+++ b/src/sillyscene.h
@@ -12,6 +12,8 @@
 class SillyScene : public Scene
 {
 private:
+    void SceneTransition() override;
+
     float yaw = -90, pitch = -45, speed_fwd = 0, speed_right = 0;
     float lastX = 0, lastY = 0;
     float fov = 50.0f;
@@ -29,6 +31,9 @@ public:
     SillyScene(SillyScene&&) = default;
     SillyScene& operator=(SillyScene&&) = default;
     ~SillyScene() = default;
+
+    std::unique_ptr<Scene> GetTransitionTarget() const override;
+
     void Update(double dt);
     void OnKey(GLFWwindow* window, int key, int scancode, int action, int mod) override;
     void OnMouse(GLFWwindow* window, double xpos, double ypos) override;


### PR DESCRIPTION
Press X for demo: currently 'resets' the scene.
Initiate a transition using `SceneTransition()`. This is also where you should pass any parameters, e.g. which grid map file to use next.
Create & configure the actual scene object within `GetTransitionTarget()`.