### PR TITLE
Scene transition grid map cycling

### DIFF
--- a/src/sillyscene.cpp
+++ b/src/sillyscene.cpp
@@ -24,7 +24,7 @@ void SillyScene::SceneTransition() {
 	Scene::SceneTransition();
 }
 
-SillyScene::SillyScene() {
+SillyScene::SillyScene(int mapID) : currentMap(mapID) {
 	activeCamera = RTSCamera(startCameraPosition);
 	activeCamera.SetCameraHeightCap(true, cameraHeightCap);
 	activeCamera.PushLight(Camera::PointLight(
@@ -34,6 +34,8 @@ SillyScene::SillyScene() {
 		{1.0f, 0.9f, 0.6f},
 		1.4f, 0.6f, 1.f
 	));
+
+	std::cerr << "Loading SillyScene with map #" << currentMap << std::endl;
 
 	auto objAssimpAnimated = std::make_unique<AnimatedObject>(glm::vec3(0.1f, 0.1f, 0.1f), 20.0f);
  	Instantiate(std::move(objAssimpAnimated));
@@ -85,7 +87,7 @@ SillyScene::SillyScene() {
 
 std::unique_ptr<Scene> SillyScene::GetTransitionTarget() const {
 	// If necessary, use different Scene subtype
-	auto scn = std::make_unique<SillyScene>();
+	auto scn = std::make_unique<SillyScene>((currentMap + 1) % numAvailableMaps);
 	
 	// Apply saved parameters
 

--- a/src/sillyscene.h
+++ b/src/sillyscene.h
@@ -13,6 +13,9 @@ class SillyScene : public Scene
 {
 private:
     void SceneTransition() override;
+    int currentMap;
+
+    static const int numAvailableMaps = 4;
 
     float yaw = -90, pitch = -45, speed_fwd = 0, speed_right = 0;
     float lastX = 0, lastY = 0;
@@ -25,7 +28,7 @@ private:
     MobManager mobManager; 
     std::unique_ptr<GameGrid> grid;
 public:
-    SillyScene();
+    SillyScene(int mapID = 0);
     SillyScene(const SillyScene&) = delete;
     SillyScene& operator=(const SillyScene&) = delete;
     SillyScene(SillyScene&&) = default;


### PR DESCRIPTION
We now need only a function to convert mapID -> map in the SillyScene constructor.
Number of available maps is defined as a constant in `sillyscene.h`, but can be moved to `Resources` if necessary.
The mapID passed to the scene constructor increases by one on every X-key press.