### PR TITLE
AnimatedObject shading

### DIFF
--- a/bin/f_animated.glsl
+++ b/bin/f_animated.glsl
@@ -29,7 +29,7 @@ in vec3 iNormal;
 in vec3 iPosition;
 in vec3 iViewDir;
 
-vec3 PointLightComponent(PointLight light, vec3 normal, vec3 viewDir, vec3 lightDir) {
+vec3 PointLightComponent(PointLight light, vec3 normal, vec3 viewDir, vec3 specularColor, vec3 lightDir) {
 	vec3 reflectDir = reflect(-lightDir, normal);
 
     float diffStrength = max(dot(normal, lightDir), 0.0);
@@ -49,11 +49,11 @@ void main(void) {
 
 	vec3 dirDiffuse = dirDiffuseColor * max(dot(vec4(normal, 0.0), lightDir), 0.0);
 
-	vec3 specColor = texture(texSpecular, texCoords);
+	vec3 specColor = texture(texSpecular, texCoords).rgb;
 
 	vec3 lightColor = dirDiffuse + dirAmbientColor;
 	for (int i = 0; i < NUM_POINT_LIGHTS; i++) {
-        lightColor += PointLightComponent(lights[i], normal, viewDir, normalize(iPosition - lights[i].position));
+        lightColor += PointLightComponent(lights[i], normal, viewDir, specColor, normalize(iPosition - lights[i].position));
     }
 
 	pixelColor = texture(tex, texCoords) * vec4(lightColor, 1.0);

--- a/bin/f_animated.glsl
+++ b/bin/f_animated.glsl
@@ -18,6 +18,7 @@ uniform vec3 dirAmbientColor;
 uniform vec3 dirDiffuseColor;
 uniform vec4 lightDir;
 uniform sampler2D tex;
+uniform sampler2D texSpecular;
 uniform PointLight lights[NUM_POINT_LIGHTS];
 
 out vec4 pixelColor; //Zmienna wyjsciowa fragment shadera. Zapisuje sie do niej ostateczny (prawie) kolor piksela
@@ -26,26 +27,33 @@ out vec4 pixelColor; //Zmienna wyjsciowa fragment shadera. Zapisuje sie do niej 
 in vec2 texCoords;
 in vec3 iNormal;
 in vec3 iPosition;
+in vec3 iViewDir;
 
-vec3 PointLightComponent(PointLight light, vec3 normal, vec3 lightDir) {
-    float diffStrength = max(dot(normal, normalize(lightDir)), 0.0);
+vec3 PointLightComponent(PointLight light, vec3 normal, vec3 viewDir, vec3 lightDir) {
+	vec3 reflectDir = reflect(-lightDir, normal);
+
+    float diffStrength = max(dot(normal, lightDir), 0.0);
+	float specStrength = pow(max(dot(viewDir, reflectDir), 0.0), 32);
 
     float r = distance(light.position, iPosition);
     float att = 1 / (r * r * light.A + r * light.B + light.C);
 
-    vec3 total = light.ambient + light.diffuse * diffStrength;
+    vec3 total = light.ambient + light.diffuse * diffStrength + light.specular * specStrength;
 
     return total * att;
 }
 
 void main(void) {
 	vec3 normal = normalize(iNormal);
+	vec3 viewDir = normalize(iViewDir);
 
 	vec3 dirDiffuse = dirDiffuseColor * max(dot(vec4(normal, 0.0), lightDir), 0.0);
 
+	vec3 specColor = texture(texSpecular, texCoords);
+
 	vec3 lightColor = dirDiffuse + dirAmbientColor;
 	for (int i = 0; i < NUM_POINT_LIGHTS; i++) {
-        lightColor += PointLightComponent(lights[i], normal, iPosition - lights[i].position);
+        lightColor += PointLightComponent(lights[i], normal, viewDir, normalize(iPosition - lights[i].position));
     }
 
 	pixelColor = texture(tex, texCoords) * vec4(lightColor, 1.0);

--- a/bin/f_animated.glsl
+++ b/bin/f_animated.glsl
@@ -1,15 +1,52 @@
 #version 330
 
+struct PointLight {
+    vec3 position;
+    
+    vec3 ambient;
+    vec3 diffuse;
+    vec3 specular;
 
+    float A;
+    float B;
+    float C;
+};
+
+#define NUM_POINT_LIGHTS 1
+
+uniform vec3 dirAmbientColor;
+uniform vec3 dirDiffuseColor;
+uniform vec4 lightDir;
 uniform sampler2D tex;
+uniform PointLight lights[NUM_POINT_LIGHTS];
 
 out vec4 pixelColor; //Zmienna wyjsciowa fragment shadera. Zapisuje sie do niej ostateczny (prawie) kolor piksela
 
 //Zmienne interpolowane
 in vec2 texCoords;
+in vec3 iNormal;
+in vec3 iPosition;
 
+vec3 PointLightComponent(PointLight light, vec3 normal, vec3 lightDir) {
+    float diffStrength = max(dot(normal, normalize(lightDir)), 0.0);
+
+    float r = distance(light.position, iPosition);
+    float att = 1 / (r * r * light.A + r * light.B + light.C);
+
+    vec3 total = light.ambient + light.diffuse * diffStrength;
+
+    return total * att;
+}
 
 void main(void) {
-	pixelColor=texture(tex,texCoords);
-	//pixelColor=vec4(color,1.0);
+	vec3 normal = normalize(iNormal);
+
+	vec3 dirDiffuse = dirDiffuseColor * max(dot(vec4(normal, 0.0), lightDir), 0.0);
+
+	vec3 lightColor = dirDiffuse + dirAmbientColor;
+	for (int i = 0; i < NUM_POINT_LIGHTS; i++) {
+        lightColor += PointLightComponent(lights[i], normal, iPosition - lights[i].position);
+    }
+
+	pixelColor = texture(tex, texCoords) * vec4(lightColor, 1.0);
 }

--- a/bin/v_animated.glsl
+++ b/bin/v_animated.glsl
@@ -9,6 +9,7 @@ layout(location = 4) in vec4 weights;
 uniform mat4 P;
 uniform mat4 V;
 uniform mat4 M;
+uniform vec3 cameraPos;
 	
 const int MAX_BONES = 100;
 const int MAX_BONE_INFLUENCE = 4;
@@ -17,6 +18,7 @@ uniform mat4 finalBonesMatrices[MAX_BONES];
 out vec2 texCoords;
 out vec3 iNormal;
 out vec3 iPosition;
+out vec3 iViewDir;
 	
 void main()
 {
@@ -41,6 +43,7 @@ void main()
 
     iPosition = totalPosition.xyz;
     iNormal = totalNormal;
+    iViewDir = cameraPos - totalPosition.xyz;
 		
     mat4 viewModel = V * M;
     gl_Position =  P * viewModel * totalPosition;

--- a/bin/v_animated.glsl
+++ b/bin/v_animated.glsl
@@ -15,11 +15,14 @@ const int MAX_BONE_INFLUENCE = 4;
 uniform mat4 finalBonesMatrices[MAX_BONES];
 	
 out vec2 texCoords;
+out vec3 iNormal;
+out vec3 iPosition;
 	
 void main()
 {
     ivec4 intBones = ivec4(boneIds);
     vec4 totalPosition = vec4(0.0);
+    vec3 totalNormal = vec3(0.0);
 
     for(int i = 0 ; i < MAX_BONE_INFLUENCE ; i++)
     {
@@ -32,8 +35,12 @@ void main()
         }
         vec4 localPosition = finalBonesMatrices[intBones[i]] * vec4(pos,1.0);
         totalPosition += localPosition * weights[i];
-        // vec3 localNormal = mat3(finalBonesMatrices[intBones[i]]) * norm;
+        vec3 localNormal = mat3(finalBonesMatrices[intBones[i]]) * norm * weights[i];
+        totalNormal += localNormal;
     }
+
+    iPosition = totalPosition.xyz;
+    iNormal = totalNormal;
 		
     mat4 viewModel = V * M;
     gl_Position =  P * viewModel * totalPosition;

--- a/src/animatedobject.cpp
+++ b/src/animatedobject.cpp
@@ -112,6 +112,10 @@ void AnimatedObject::Draw(const Camera& camera) const {
     glBindTexture(GL_TEXTURE_2D, texture);
     glUniform1i(spAnimated->u("tex"), 0);
 
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, textSpecular);
+    glUniform1i(spAnimated->u("texSpecular"), 1);
+
     // std::cout<<"Started drawing triangles"<<std::endl;
     glDrawElements(GL_TRIANGLES, meshes[0].indices.size(), GL_UNSIGNED_INT, meshes[0].indices.data());
     // std::cout<<"Finished drawing triangles"<<std::endl;

--- a/src/animatedobject.cpp
+++ b/src/animatedobject.cpp
@@ -80,14 +80,20 @@ void AnimatedObject::Draw(const Camera& camera) const {
 	glUniform3f(spAnimated->u("dirDiffuseColor"), 0.5f, 0.5f, 0.5f);
 	glUniform4f(spAnimated->u("lightDir"), 0.2f, -1.0f, 0.0f, 0.0f);
 
-    auto pLight = camera.GetLights()[0];
-	glUniform3fv(spAnimated->u("lights[0].position"), 1, glm::value_ptr(pLight.position));
-	glUniform3fv(spAnimated->u("lights[0].ambient"), 1, glm::value_ptr(pLight.ambient));
-	glUniform3fv(spAnimated->u("lights[0].diffuse"), 1, glm::value_ptr(pLight.diffuse));
-	glUniform3fv(spAnimated->u("lights[0].specular"), 1, glm::value_ptr(pLight.specular));
-	glUniform1f(spAnimated->u("lights[0].A"), pLight.A);
-	glUniform1f(spAnimated->u("lights[0].B"), pLight.B);
-	glUniform1f(spAnimated->u("lights[0].C"), pLight.C);
+    auto pLights = camera.GetLights();
+    for (int i = 0; i < pLights.size(); ++i) {
+        std::string attrPrefix = "lights[" + std::to_string(i) + "].";
+
+        auto& pLight = pLights[i];
+
+        glUniform3fv(spAnimated->u((attrPrefix + "position").c_str()), 1, glm::value_ptr(pLight.position));
+        glUniform3fv(spAnimated->u((attrPrefix + "ambient").c_str()), 1, glm::value_ptr(pLight.ambient));
+        glUniform3fv(spAnimated->u((attrPrefix + "diffuse").c_str()), 1, glm::value_ptr(pLight.diffuse));
+        glUniform3fv(spAnimated->u((attrPrefix + "specular").c_str()), 1, glm::value_ptr(pLight.specular));
+        glUniform1f(spAnimated->u((attrPrefix + "A").c_str()), pLight.A);
+        glUniform1f(spAnimated->u((attrPrefix + "B").c_str()), pLight.B);
+        glUniform1f(spAnimated->u((attrPrefix + "C").c_str()), pLight.C);
+    }
 
 
 	glEnableVertexAttribArray(spAnimated->a("pos"));

--- a/src/animatedobject.cpp
+++ b/src/animatedobject.cpp
@@ -74,6 +74,20 @@ void AnimatedObject::Draw(const Camera& camera) const {
 	    glUniformMatrix4fv(spAnimated->u(finalBones.c_str()), 1, false, glm::value_ptr(transforms[i]));
     }
 
+    glUniform3f(spAnimated->u("dirAmbientColor"), 0.2f, 0.2f, 0.2f);
+	glUniform3f(spAnimated->u("dirDiffuseColor"), 0.5f, 0.5f, 0.5f);
+	glUniform4f(spAnimated->u("lightDir"), 0.2f, -1.0f, 0.0f, 0.0f);
+
+    auto pLight = camera.GetLights()[0];
+	glUniform3fv(spAnimated->u("lights[0].position"), 1, glm::value_ptr(pLight.position));
+	glUniform3fv(spAnimated->u("lights[0].ambient"), 1, glm::value_ptr(pLight.ambient));
+	glUniform3fv(spAnimated->u("lights[0].diffuse"), 1, glm::value_ptr(pLight.diffuse));
+	glUniform3fv(spAnimated->u("lights[0].specular"), 1, glm::value_ptr(pLight.specular));
+	glUniform1f(spAnimated->u("lights[0].A"), pLight.A);
+	glUniform1f(spAnimated->u("lights[0].B"), pLight.B);
+	glUniform1f(spAnimated->u("lights[0].C"), pLight.C);
+
+
 	glEnableVertexAttribArray(spAnimated->a("pos"));
 	glVertexAttribPointer(spAnimated->a("pos"), 3, GL_FLOAT, false, 0, meshes[0].vertices.data()); 
         

--- a/src/animatedobject.cpp
+++ b/src/animatedobject.cpp
@@ -74,6 +74,8 @@ void AnimatedObject::Draw(const Camera& camera) const {
 	    glUniformMatrix4fv(spAnimated->u(finalBones.c_str()), 1, false, glm::value_ptr(transforms[i]));
     }
 
+    glUniform3fv(spAnimated->u("cameraPos"), 1, glm::value_ptr(camera.GetPosition()));
+
     glUniform3f(spAnimated->u("dirAmbientColor"), 0.2f, 0.2f, 0.2f);
 	glUniform3f(spAnimated->u("dirDiffuseColor"), 0.5f, 0.5f, 0.5f);
 	glUniform4f(spAnimated->u("lightDir"), 0.2f, -1.0f, 0.0f, 0.0f);

--- a/src/gridobject.cpp
+++ b/src/gridobject.cpp
@@ -22,14 +22,20 @@ void GridObject::Draw(const Camera& camera) const {
 	glUniform3f(spTerrain->u("diffuseColor"), 0.5f, 0.5f, 0.5f);
 	glUniform4f(spTerrain->u("lightDir"), 0.2f, -1.0f, 0.0f, 0.0f);
 
-	auto pLight = camera.GetLights()[0];
-	glUniform3fv(spTerrain->u("lights[0].position"), 1, glm::value_ptr(pLight.position));
-	glUniform3fv(spTerrain->u("lights[0].ambient"), 1, glm::value_ptr(pLight.ambient));
-	glUniform3fv(spTerrain->u("lights[0].diffuse"), 1, glm::value_ptr(pLight.diffuse));
-	// specular is unused in the terrain shader
-	glUniform1f(spTerrain->u("lights[0].A"), pLight.A);
-	glUniform1f(spTerrain->u("lights[0].B"), pLight.B);
-	glUniform1f(spTerrain->u("lights[0].C"), pLight.C);
+	auto pLights = camera.GetLights();
+    for (int i = 0; i < pLights.size(); ++i) {
+        std::string attrPrefix = "lights[" + std::to_string(i) + "].";
+
+        auto& pLight = pLights[i];
+
+        glUniform3fv(spAnimated->u((attrPrefix + "position").c_str()), 1, glm::value_ptr(pLight.position));
+        glUniform3fv(spAnimated->u((attrPrefix + "ambient").c_str()), 1, glm::value_ptr(pLight.ambient));
+        glUniform3fv(spAnimated->u((attrPrefix + "diffuse").c_str()), 1, glm::value_ptr(pLight.diffuse));
+        glUniform3fv(spAnimated->u((attrPrefix + "specular").c_str()), 1, glm::value_ptr(pLight.specular));
+        glUniform1f(spAnimated->u((attrPrefix + "A").c_str()), pLight.A);
+        glUniform1f(spAnimated->u((attrPrefix + "B").c_str()), pLight.B);
+        glUniform1f(spAnimated->u((attrPrefix + "C").c_str()), pLight.C);
+    }
 
 
 

--- a/src/sillyscene.cpp
+++ b/src/sillyscene.cpp
@@ -76,7 +76,7 @@ SillyScene::SillyScene() {
 	Instantiate(gridObj);
 
 	activeCamera.PushLight(Camera::PointLight(
-		{0.f, 0.5f, 0.f},//grid->getExitPoint() + glm::vec3(0.f, .6f, 0.f),
+		grid->getExitPoint() + glm::vec3(0.f, .6f, 0.f),
 		{0.05f, 0.05f, 0.05f},
 		{0.9f, 0.8f, 0.4f},
 		{1.0f, 0.9f, 0.6f},

--- a/src/sillyscene.cpp
+++ b/src/sillyscene.cpp
@@ -76,7 +76,7 @@ SillyScene::SillyScene() {
 	Instantiate(gridObj);
 
 	activeCamera.PushLight(Camera::PointLight(
-		grid->getExitPoint() + glm::vec3(0.f, .6f, 0.f),
+		{0.f, 0.5f, 0.f},//grid->getExitPoint() + glm::vec3(0.f, .6f, 0.f),
 		{0.05f, 0.05f, 0.05f},
 		{0.9f, 0.8f, 0.4f},
 		{1.0f, 0.9f, 0.6f},


### PR DESCRIPTION
Modifies `spAnimated`.
Implements spaghetti-Phong lighting model.
Respects specular map texture.
Adjust point light parameters (`PushLight` in `SillyScene`) to work nicely in the final scene.